### PR TITLE
Manage UI Menu `disabled` flag

### DIFF
--- a/chunks/manageButtonsUI_init.lua
+++ b/chunks/manageButtonsUI_init.lua
@@ -1,18 +1,27 @@
 function manageButtonsUI:init(gameUI, manageUI_, hubUI_, world)
-
     manageUI = manageUI_
     hubUI = hubUI_
-    
+
     local menuButtonSize = manageButtonsUI.menuButtonSize
     local menuButtonPaddingRatio = manageButtonsUI.menuButtonPaddingRatio
-    
+
     local menuButtonPadding = menuButtonSize * menuButtonPaddingRatio
     
+    local menuButtonsEnabled = 0
+    for modeIndex in ipairs(manageUI.modeTypes) do
+        if not manageUI.modeInfos[modeIndex].disabled then
+            menuButtonsEnabled  = menuButtonsEnabled + 1
+        end
+    end
+
+
     local menuButtonsView = View.new(gameUI.view)
     manageButtonsUI.menuButtonsView = menuButtonsView
     menuButtonsView.hidden = true
     menuButtonsView.relativePosition = ViewPosition(MJPositionCenter, MJPositionTop)
-    menuButtonsView.size = vec2(menuButtonSize * manageButtonsUI.menuButtonCount + menuButtonPadding * (manageButtonsUI.menuButtonCount - 1), menuButtonSize)
+    menuButtonsView.size = vec2(
+        menuButtonSize * menuButtonsEnabled + menuButtonPadding * (menuButtonsEnabled - 1),
+        menuButtonSize)
     menuButtonsView.baseOffset = vec3(0.0, -40.0, 0.0)
 
     local toolTipOffset = manageButtonsUI.toolTipOffset
@@ -20,23 +29,32 @@ function manageButtonsUI:init(gameUI, manageUI_, hubUI_, world)
     manageButtonsUI.orderedModes = {}
 
     local lastButton = nil
-    for modeIndex in ipairs(manageUI.modeTypes) do 
+    for modeIndex in ipairs(manageUI.modeTypes) do
+        mj:log(manageUI.modeInfos[modeIndex])
+        if manageUI.modeInfos[modeIndex].disabled then
+            goto continue
+        end
+
         mj:log("manageButtonsUI: modeIndex=", modeIndex, " title=", manageUI.modeInfos[modeIndex].title)
         table.insert(manageButtonsUI.orderedModes, modeIndex)
 
+
         local horizontalPos = modeIndex == 1 and MJPositionInnerLeft or MJPositionOuterRight
 
-        local button = uiStandardButton:create(menuButtonsView, vec2(menuButtonSize,menuButtonSize), uiStandardButton.types.markerLike)
+        local button = uiStandardButton:create(menuButtonsView, vec2(menuButtonSize, menuButtonSize),
+            uiStandardButton.types.markerLike)
         button.relativePosition = ViewPosition(horizontalPos, MJPositionCenter)
         uiStandardButton:setIconModel(button, manageUI.modeInfos[modeIndex].icon)
-        uiToolTip:add(button.userData.backgroundView, ViewPosition(MJPositionCenter, MJPositionBelow), manageUI.modeInfos[modeIndex].title, nil, toolTipOffset, nil, button)
+        uiToolTip:add(button.userData.backgroundView, ViewPosition(MJPositionCenter, MJPositionBelow),
+            manageUI.modeInfos[modeIndex].title, nil, toolTipOffset, nil, button)
 
         if lastButton then
             button.relativeView = lastButton
         end
 
         if manageUI.modeInfos[modeIndex].keyboardShortcut then
-            uiToolTip:addKeyboardShortcut(button.userData.backgroundView, "game", manageUI.modeInfos[modeIndex].keyboardShortcut, nil, nil)
+            uiToolTip:addKeyboardShortcut(button.userData.backgroundView, "game",
+                manageUI.modeInfos[modeIndex].keyboardShortcut, nil, nil)
         end
 
         uiStandardButton:setClickFunction(button, function()
@@ -48,17 +66,18 @@ function manageButtonsUI:init(gameUI, manageUI_, hubUI_, world)
 
         manageButtonsUI.menuButtonsByManageUIModeType[modeIndex] = button
         lastButton = button
+        ::continue::
     end
-    
+
     menuButtonsView.hiddenStateChanged = function(newHiddenState)
         if newHiddenState then
-            for modeIndex,button in pairs(manageButtonsUI.menuButtonsByManageUIModeType) do
+            for modeIndex, button in pairs(manageButtonsUI.menuButtonsByManageUIModeType) do
                 uiStandardButton:resetAnimationState(button)
             end
         end
     end
 
-    
+
     eventManager:addControllerCallback(eventManager.controllerSetIndexMenu, true, "menuTabLeft", function(isDown)
         if isDown and not menuButtonsView.hidden then
             if manageUI:hidden() then
@@ -98,5 +117,4 @@ function manageButtonsUI:init(gameUI, manageUI_, hubUI_, world)
             return true
         end
     end)
-
 end

--- a/chunks/manageButtonsUI_init.lua
+++ b/chunks/manageButtonsUI_init.lua
@@ -30,13 +30,14 @@ function manageButtonsUI:init(gameUI, manageUI_, hubUI_, world)
 
     local lastButton = nil
     for modeIndex in ipairs(manageUI.modeTypes) do
-        mj:log(manageUI.modeInfos[modeIndex])
+        mj:log("manageButtonsUI: modeIndex=", modeIndex, " title=", manageUI.modeInfos[modeIndex].title)
+        table.insert(manageButtonsUI.orderedModes, modeIndex)
+
         if manageUI.modeInfos[modeIndex].disabled then
+            mj:log("manageButton at modeIndex=", modeIndex, " title=", manageUI.modeInfos[modeIndex].title, " is disabled, skipping button creation")
             goto continue
         end
 
-        mj:log("manageButtonsUI: modeIndex=", modeIndex, " title=", manageUI.modeInfos[modeIndex].title)
-        table.insert(manageButtonsUI.orderedModes, modeIndex)
 
 
         local horizontalPos = modeIndex == 1 and MJPositionInnerLeft or MJPositionOuterRight

--- a/scripts/hammerstone/options/modOptionsManager.lua
+++ b/scripts/hammerstone/options/modOptionsManager.lua
@@ -9,7 +9,7 @@ local log = mjrequire "hammerstone/logging"
 
 local world = nil
 
-local modOptionsList = hmt{}
+local modOptionsList = hmt {}
 local clientModOptions = nil
 local listeners = {}
 
@@ -19,7 +19,7 @@ local modOptionsManager = {}
 
 local function saveClientModOptions()
     local clientWorldSettingsDatabase = world:getClientWorldSettingsDatabase()
-	clientWorldSettingsDatabase:setDataForKey(clientModOptions, databaseKey)
+    clientWorldSettingsDatabase:setDataForKey(clientModOptions, databaseKey)
 end
 
 local function optionsErrorHandler(hmTable_, errorCode, parentTable, fieldKey, msg, ...)
@@ -30,8 +30,7 @@ end
 local function initOptionsForMod(configKey, modOptions)
     clientModOptions[configKey] = clientModOptions[configKey] or {}
 
-    for optionName, option in pairs(modOptions) do 
-        
+    for optionName, option in pairs(modOptions) do
         if not clientModOptions[configKey][optionName] and option.default_value then
             clientModOptions[configKey][optionName] = option.default_value
         end
@@ -45,36 +44,35 @@ end
 function modOptionsManager:init(modManager)
     log:schema("options", "Initializing mod options")
     local mods = modManager.enabledModDirNamesAndVersionsByType.world
-	
-	for i, mod in ipairs(mods) do
+
+    for i, mod in ipairs(mods) do
         local optionsPath = mod.path .. "/hammerstone/options"
         modOptionsManager:findOptionsFiles(optionsPath)
-	end
+    end
 end
 
 function modOptionsManager:registerUI()
-    local uiManager = mjrequire "hammerstone/ui/uiManager"
-	local modOptionsUI = mjrequire "hammerstone/options/modOptionsUI"
+    log:schema("options", "Registering mod options UI...")
 
-	modOptionsUI:setModOptionsManager(self)
+    local uiManager = mjrequire "hammerstone/ui/uiManager"
+    local modOptionsUI = mjrequire "hammerstone/options/modOptionsUI"
+
+    modOptionsUI:setModOptionsManager(self)
     uiManager:registerManageElement(modOptionsUI)
 end
 
 function modOptionsManager:findOptionsFiles(path)
     local optionsPaths = fileUtils.getDirectoryContents(path)
 
-	for j, optionsPath in ipairs(optionsPaths) do
+    for j, optionsPath in ipairs(optionsPaths) do
+        local fullPath = path .. "/" .. optionsPath
 
-		local fullPath =  path .. "/" .. optionsPath
-		
-		if fullPath:find("%.json$") then
+        if fullPath:find("%.json$") then
             log:schema("options", "Found json mod options file at ", fullPath)
             local jsonString = fileUtils.getFileContents(fullPath)
 
             local modOptions = hmt(json:decode(jsonString), optionsErrorHandler)
             modOptionsList[modOptions:getStringValue("configKey")] = modOptions
-            
-
         elseif fullPath:find("%.lua$") then
             log:schema("options", "Found lua mod options file at ", fullPath)
             local chunk, errMsg = loadfile(fullPath)
@@ -101,10 +99,10 @@ function modOptionsManager:findOptionsFiles(path)
                     listeners[configKey] = modOptions:get("listener"):ofType("function"):getValue()
                 end
             end
-		else
-			modOptionsManager:findOptionsFiles(fullPath)
-		end
-	end
+        else
+            modOptionsManager:findOptionsFiles(fullPath)
+        end
+    end
 end
 
 function modOptionsManager:setWorld(world_)
@@ -113,7 +111,7 @@ function modOptionsManager:setWorld(world_)
     local clientWorldSettingsDatabase = world:getClientWorldSettingsDatabase()
     clientModOptions = clientWorldSettingsDatabase:dataForKey(databaseKey) or {}
 
-    for configKey, modOptions in pairs(modOptionsList) do 
+    for configKey, modOptions in pairs(modOptionsList) do
         initOptionsForMod(configKey, modOptions:getTable("options"))
     end
 
@@ -160,7 +158,7 @@ function modOptionsManager:setModOptionsValue(configKey, optionKey, value)
     clientModOptions[configKey][optionKey] = value
     saveClientModOptions()
 
-    if listeners[configKey] then listeners[configKey]({{optionKey = optionKey, value = value}}) end
+    if listeners[configKey] then listeners[configKey]({ { optionKey = optionKey, value = value } }) end
 end
 
 return modOptionsManager

--- a/scripts/hammerstone/options/modOptionsUI.lua
+++ b/scripts/hammerstone/options/modOptionsUI.lua
@@ -26,6 +26,7 @@ local modOptionsUI = {
 	view = nil,
 	parent = nil,
 	icon = "icon_modOptions",
+    disabled = false,
 }
 
 local viewsByEnableCondition = {}
@@ -121,6 +122,7 @@ function modOptionsUI:init(contentView, manageUI_)
 end
 
 function modOptionsUI:initOptions()
+    log:schema("options", "Initializing UI options...")
     if modOptionsManager:hasOptions() then
         modOptionsUI:initModOptionsViews()
     else

--- a/scripts/hammerstone/ui/uiManager.lua
+++ b/scripts/hammerstone/ui/uiManager.lua
@@ -70,22 +70,22 @@ function uiManager:initManageElementButtons(manageButtonsUI, manageUI)
 
 	for modeIndex in ipairs(manageUI.modeTypes) do
 		nextIndex = math.max(nextIndex, modeIndex)
-	end 
+	end
 
 	for i, element in ipairs(self.manageElements) do
-		logger:log("Adding Manage Element Button: ", element.name)
+		logger:schema("ui", "Adding Manage Element Button: ", element.name)
 		local elementIndex = nextIndex + i
 		local elementModeType = string.format("manageElement_%d", i)
 		modeTypes[elementIndex] = elementModeType
 		modeTypes[elementModeType] = elementIndex
-
 		manageUI.modeInfos[elementIndex] = {
 			title = element.name,
-			icon = element.icon, 
-			onClick = element.onClick
+			icon = element.icon,
+			onClick = element.onClick,
+			disabled = element.disabled,
 		}
 
-		-- Increase the number of buttons to be displayed
+		-- Increase the number of buttons there are (disabled buttons don't count towards padding - check the init patch)
 		manageButtonsUI.menuButtonCount = manageButtonsUI.menuButtonCount + 1
 	end
 
@@ -159,25 +159,24 @@ function uiManager:initActionView(gameUI, hubUI, world)
 	self.actionContainerView.baseOffset = vec3(500, 0, 0) -- TODO: Try not to hard-code magic numbers!
 end
 
-
 --- This function is called when the Radial Menu is opened, and will be used to render
 --- the action elements, based on their own internal logic and structure.
 --- TODO: Consider adding a priority function.
 --- @param baseObjectInfo table - Object info for single objects.localecategory
 --- @param multiSelectAllObjects table - Object info for multi-select objects
---- @param lookAtPos unknown - 
+--- @param lookAtPos unknown -
 function uiManager:renderActionElements(baseObjectInfo, multiSelectAllObjects, lookAtPos, isTerrain)
 	-- Does this destroy the internal view?
 	-- TODO: No it doesn't, maybe cause refs are still kept in the container view.
-	
+
 	for _, element in ipairs(self.actionElementsRendered) do
 		self.actionContainerView:removeSubview(element)
 	end
 	self.actionElementsRendered = {}
 
-	
+
 	local vertical_offset = 0
-	for i,element in ipairs(self.actionElements) do
+	for i, element in ipairs(self.actionElements) do
 		if element:visibilityFilter(baseObjectInfo, multiSelectAllObjects, lookAtPos, isTerrain) then
 			-- TODO: Consider moving this into it's own function.
 
@@ -188,7 +187,7 @@ function uiManager:renderActionElements(baseObjectInfo, multiSelectAllObjects, l
 			local button = uiStandardButton:create(self.actionContainerView, buttonSize)
 			button.relativePosition = ViewPosition(MJPositionCenter, MJPositionTop)
 			button.baseOffset = vec3(0, vertical_offset, 5)
-			
+
 			-- You have two options for setting the name
 			local elementName = element.name
 			if elementName == nil and element.getName ~= nil then


### PR DESCRIPTION
Adds a `disabled` flag to Manage UI elements that prevents them from being rendered, while still allowing them to be registered. Was initially going to use to complete #41, but Witchy wanted to take that over. 